### PR TITLE
Acts as regexp

### DIFF
--- a/lib/hexpress.rb
+++ b/lib/hexpress.rb
@@ -1,4 +1,7 @@
 class Hexpress
+  extend Forwardable
+  def_delegators :to_regexp, :=~, :===, :match
+
   CHARACTERS = [:word, :digit, :space]
   attr_reader :expressions
 

--- a/lib/hexpress.rb
+++ b/lib/hexpress.rb
@@ -66,9 +66,10 @@ class Hexpress
   end
 
   # This method returns the regular hexpression form of this object.
-  def to_r
+  def to_regexp
     Regexp.new(to_s)
   end
+  alias_method :to_r, :to_regexp
 
   # This method returns the string version of the regexp.
   def to_s

--- a/spec/lib/hexpress_spec.rb
+++ b/spec/lib/hexpress_spec.rb
@@ -89,29 +89,29 @@ describe Hexpress do
 
   describe "#to_regexp" do
     it "should return a Regexp object" do
-      Hexpress.new.to_regexp.should be_a(Regexp)
+      expect(Hexpress.new.to_regexp).to be_a(Regexp)
     end
   end
 
   describe "acts as a Regexp" do
     it "should work for Regexp#try_convert" do
-      Regexp.try_convert(Hexpress.new).should_not be_nil
+      expect(Regexp.try_convert(Hexpress.new)).not_to be_nil
     end
 
     it "should be able to match" do
-      Hexpress.new.with("foo").match("foo").should_not be_nil
+      expect(Hexpress.new.with("foo").match("foo")).to_not be_nil
     end
 
     it "should match using #=~" do
-      (Hexpress.new.with("foo") =~ "foo").should eq(0)
+      expect(Hexpress.new.with("foo") =~ "foo").to eq(0)
     end
 
     it "should match using ===" do
-      (Hexpress.new.with("foo") === "foo").should be_true
+      expect(Hexpress.new.with("foo") === "foo").to be_true
     end
 
     it "should be able to be matched by strings using =~" do
-      ("foo" =~ Hexpress.new.with("foo")).should be_true
+      expect("foo" =~ Hexpress.new.with("foo")).to be_true
     end
   end
 end

--- a/spec/lib/hexpress_spec.rb
+++ b/spec/lib/hexpress_spec.rb
@@ -86,4 +86,14 @@ describe Hexpress do
       expect(pattern4.to_r).to eq(/foobarbang/)
     end
   end
+
+  describe "#to_regexp" do
+    it "should return a Regexp object" do
+      Hexpress.new.to_regexp.should be_a(Regexp)
+    end
+
+    it "should work for Regexp#try_convert" do
+      Regexp.try_convert(Hexpress.new).should_not be_nil
+    end
+  end
 end

--- a/spec/lib/hexpress_spec.rb
+++ b/spec/lib/hexpress_spec.rb
@@ -91,9 +91,27 @@ describe Hexpress do
     it "should return a Regexp object" do
       Hexpress.new.to_regexp.should be_a(Regexp)
     end
+  end
 
+  describe "acts as a Regexp" do
     it "should work for Regexp#try_convert" do
       Regexp.try_convert(Hexpress.new).should_not be_nil
+    end
+
+    it "should be able to match" do
+      Hexpress.new.with("foo").match("foo").should_not be_nil
+    end
+
+    it "should match using #=~" do
+      (Hexpress.new.with("foo") =~ "foo").should eq(0)
+    end
+
+    it "should match using ===" do
+      (Hexpress.new.with("foo") === "foo").should be_true
+    end
+
+    it "should be able to be matched by strings using =~" do
+      ("foo" =~ Hexpress.new.with("foo")).should be_true
     end
   end
 end


### PR DESCRIPTION
This patch makes a Hexpress instance act more like a Regexp class. It'll facilitate such uses as:
- `"some string" =~ Hexpress.new.with("some") # => 0`
- `some_hexpress.match "some string"`
- `some_hexpress === "Some String"` which is very useful for case/when statements

Hope you like it and consider accepting it!
